### PR TITLE
Fix UUID validation to accept uppercase characters

### DIFF
--- a/test_validation_utils.py
+++ b/test_validation_utils.py
@@ -1,0 +1,11 @@
+import validation
+
+
+def test_validate_uuid_accepts_uppercase():
+    assert validation.validate_uuid('95EF01B7-EBFD-4320-A41B-9550E88551B5')
+    assert validation.validate_uuid('95ef01b7-EBFD-4320-A41B-9550e88551b5')
+
+
+def test_validate_uuid_rejects_invalid():
+    assert not validation.validate_uuid('not-a-uuid')
+    assert not validation.validate_uuid('123')

--- a/validation.py
+++ b/validation.py
@@ -16,7 +16,7 @@ class ValidationError(Exception):
 
 def validate_uuid(uuid_str: str) -> bool:
     """Validate UUID format."""
-    uuid_pattern = r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    uuid_pattern = r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
     return bool(re.match(uuid_pattern, uuid_str))
 
 


### PR DESCRIPTION
## Summary
- allow uppercase letters in `validate_uuid`
- add tests for UUID validation

## Testing
- `pytest test_validation_utils.py test_mastery_system.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec9ce6f4c832681e825732afa73b1