### PR TITLE
Add parent registration page for Vite frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,14 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import RegisterParent from './pages/RegisterParent'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/register/parent" element={<RegisterParent />} />
+        <Route path="/" element={<div className="p-4">Home</div>} />
+      </Routes>
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/pages/RegisterParent.tsx
+++ b/frontend/src/pages/RegisterParent.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import axios from 'axios'
+import api from '../services/api'
+
+interface ParentForm {
+  email: string
+  password: string
+  locale: string
+}
+
+interface RegisterResponse {
+  user_id: string
+  role: string
+}
+
+export default function RegisterParent() {
+  const [form, setForm] = useState<ParentForm>({ email: '', password: '', locale: 'ru' })
+  const [result, setResult] = useState<RegisterResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      const response = await api.post<RegisterResponse>('/register/parent', form)
+      setResult(response.data)
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.message || 'Registration failed')
+      } else {
+        setError('Registration failed')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4">
+      <h2 className="text-2xl font-bold mb-4">Parent Registration</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          required
+          placeholder="Email"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+          required
+          placeholder="Password"
+          className="w-full border p-2 rounded"
+        />
+        <input
+          type="text"
+          name="locale"
+          value={form.locale}
+          onChange={handleChange}
+          placeholder="Locale (e.g. ru)"
+          className="w-full border p-2 rounded"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-500 text-white py-2 rounded disabled:opacity-50"
+        >
+          {loading ? 'Registering...' : 'Register'}
+        </button>
+      </form>
+      {result && (
+        <div className="mt-4 text-green-600">
+          Registered user {result.user_id} as {result.role}
+        </div>
+      )}
+      {error && (
+        <div className="mt-4 text-red-600">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,1 +1,7 @@
+import axios from 'axios'
 
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '/api',
+})
+
+export default api


### PR DESCRIPTION
## Summary
- replace default app with router and parent registration page
- add axios API client for backend calls

## Testing
- `npm run lint`
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68af62268bac8326b0d70558a81cee1c